### PR TITLE
Use Node's randomUUID for scan IDs

### DIFF
--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -23,7 +23,7 @@ app.post('/api/scans', upload.single('file'), async (req, res) => {
     const file = req.file;
     if (!file) return res.status(400).json({ error: 'no file' });
 
-    const id = crypto.randomUUID?.() || Math.random().toString(36).slice(2);
+    const id = randomUUID();
     const inputPath = file.path;
     const outDir = path.join('storage', id);
     fs.mkdirSync(outDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Simplify unique ID generation in API by using Node's `randomUUID()`
- Drop fallback code and global `crypto` reference

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bb272f95d88322bb335596e344d37d