### PR TITLE
feat(api): enforce token-based auth

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,2 +1,4 @@
 PORT=4000
+# required token for API access
+API_TOKEN=changeme
 # BLENDER_PATH="C:\\Program Files\\Blender Foundation\\Blender 4.5\\blender.exe"

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,1 +1,4 @@
 # apps/api
+
+API requires an `API_TOKEN` environment variable. Clients must send this
+token in the `Authorization: Bearer` header with each request.

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -14,7 +14,11 @@ const upload = multer({ dest: 'uploads/' });
 
 app.use((req, res, next) => {
   const auth = req.headers.authorization || '';
-  if (!auth.startsWith('Bearer ')) return res.status(401).json({ error: 'no token' });
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!token) return res.status(401).json({ error: 'no token' });
+  if (token !== process.env.API_TOKEN) {
+    return res.status(401).json({ error: 'invalid token' });
+  }
   next();
 });
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -6,12 +6,12 @@
 cd apps\api
 npm install
 copy .env.example .env
-notepad .env   # ustaw BLENDER_PATH
+notepad .env   # ustaw BLENDER_PATH i API_TOKEN
 npm run dev    # http://localhost:4000
 ```
 Test:
 ```bat
 curl -v -X POST http://localhost:4000/api/scans ^
-  -H "Authorization: Bearer test" ^
+  -H "Authorization: Bearer <API_TOKEN>" ^
   -F "file=@C:\Users\%USERNAME%\Desktop\test.obj"
 ```


### PR DESCRIPTION
## Summary
- validate Bearer token against `API_TOKEN` env value
- document `API_TOKEN` and update sample environment file

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb2b275a84832294f291fa98954d65