### PR TITLE
Handle scan asynchronously and show progress

### DIFF
--- a/apps/android/app/src/main/res/layout/activity_main.xml
+++ b/apps/android/app/src/main/res/layout/activity_main.xml
@@ -14,6 +14,14 @@
         android:textSize="16sp"
         android:paddingBottom="8dp"/>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:visibility="gone"/>
+
     <Button
         android:id="@+id/btnScan"
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- Offload frame capture loop to a background coroutine
- Update UI on main thread when scan finishes
- Display a progress indicator while scanning

## Testing
- `gradle test` *(fails: Unexpected tokens in apps/android/app/build.gradle.kts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2f6bda408322a26df776e4ca9aa8