### PR TITLE
Refactor uploader to suspend OkHttp call

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -11,4 +11,6 @@ dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 }

--- a/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
@@ -128,7 +128,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun uploadLast() {
         val f = lastPlyFile ?: run { info.text = "Brak pliku do wysłania"; return }
-        Thread {
+        scope.launch {
             try {
                 val resp = Uploader.upload(
                     url = "http://10.0.2.2:4000/api/scans",
@@ -136,10 +136,10 @@ class MainActivity : AppCompatActivity() {
                     file = f,
                     meta = mapOf("platform" to "android", "format" to "ply")
                 )
-                runOnUiThread { info.text = resp }
+                withContext(Dispatchers.Main) { info.text = resp }
             } catch (e: Exception) {
-                runOnUiThread { info.text = "Błąd wysyłki: ${e.message}" }
+                withContext(Dispatchers.Main) { info.text = "Błąd wysyłki: ${e.message}" }
             }
-        }.start()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add OkHttp and coroutine dependencies
- implement suspend multipart upload using OkHttp
- call uploader from coroutine with exception handling

## Testing
- `gradle -p apps/android :app:assembleDebug` *(fails: Unexpected tokens in build.gradle.kts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb303d1fb88322bf2ddfceaeac51d6