### PR TITLE
feat(api): cleanup old stored scans

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -3,6 +3,15 @@
 API requires an `API_TOKEN` environment variable. Clients must send this
 token in the `Authorization: Bearer` header with each request.
 
+## Configuration
+
+The API can be configured with the following environment variables:
+
+- `STORAGE_DIR` – directory where converted scans are stored. Defaults to
+  `storage`.
+- `STORAGE_MAX_AGE_MS` – files older than this many milliseconds are removed
+  by a periodic cleanup job. Defaults to `86400000` (24 hours).
+
 ## Metadata
 
 Send additional metadata in a `meta` field when uploading scans. The value
@@ -20,6 +29,7 @@ The response contains the scan `id`. Read the saved metadata with:
 
 ```js
 import fs from 'fs/promises';
-const info = JSON.parse(await fs.readFile(`storage/${id}/info.json`, 'utf8'));
+const dir = process.env.STORAGE_DIR || 'storage';
+const info = JSON.parse(await fs.readFile(`${dir}/${id}/info.json`, 'utf8'));
 console.log(info.author);
 ```


### PR DESCRIPTION
## Summary
- add scheduled job to remove old files in storage
- allow configuring storage dir and file retention via env vars
- document new configuration and defaults

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb31b954e48322b63786b96f66f53f