### PR TITLE
Document error responses for scan endpoints

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -35,3 +35,11 @@ const dir = process.env.STORAGE_DIR || 'storage';
 const info = JSON.parse(await fs.readFile(`${dir}/${id}/info.json`, 'utf8'));
 console.log(info.author);
 ```
+
+## Responses
+
+Both `POST /api/scans` and `GET /api/scans/{id}/room.glb` may return:
+
+- `401` – Unauthorized
+- `400` – Bad request
+- `500` – Server error

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -25,3 +25,32 @@ paths:
       responses:
         '200':
           description: Conversion completed.
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthorized.
+        '500':
+          description: Server error.
+  /api/scans/{id}/room.glb:
+    get:
+      summary: Download converted GLB model by scan id.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: GLB file.
+          content:
+            model/gltf-binary:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthorized.
+        '500':
+          description: Server error.


### PR DESCRIPTION
## Summary
- Document POST /api/scans and GET /api/scans/{id}/room.glb error responses in OpenAPI
- Note possible 400/401/500 responses for scans endpoints in README

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bb39395f6c83228f5b33cac9e5d6d4