### PR TITLE
Handle AR session lifecycle in MainActivity

### DIFF
--- a/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.util.Log
 import com.google.ar.core.Config
 import com.google.ar.core.Frame
 import com.google.ar.core.PointCloud
@@ -36,6 +37,18 @@ class MainActivity : AppCompatActivity() {
 
         btnScan.setOnClickListener { startScan() }
         btnUpload.setOnClickListener { uploadLast() }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        session?.resume()
+        Log.d("MainActivity", "Session resumed")
+    }
+
+    override fun onPause() {
+        session?.pause()
+        Log.d("MainActivity", "Session paused")
+        super.onPause()
     }
 
     private fun ensureSession(): Boolean {


### PR DESCRIPTION
## Summary
- resume AR session when activity comes to foreground
- pause session when activity goes to background
- log lifecycle transitions for easier debugging

## Testing
- `gradle test` *(fails: Unexpected tokens in build.gradle.kts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb40095c788322a1d20ad6172204b7