### PR TITLE
Document 404 response for scan download endpoint

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -43,3 +43,7 @@ Both `POST /api/scans` and `GET /api/scans/{id}/room.glb` may return:
 - `401` – Unauthorized
 - `400` – Bad request
 - `500` – Server error
+
+`GET /api/scans/{id}/room.glb` may also return:
+
+- `404` – Not found

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -52,5 +52,7 @@ paths:
           description: Bad request.
         '401':
           description: Unauthorized.
+        '404':
+          description: Not found.
         '500':
           description: Server error.


### PR DESCRIPTION
## Summary
- add 404 response to GET /api/scans/{id}/room.glb in OpenAPI spec
- document 404 not found response in API README

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bb45445ffc8322b5946ac63c1ff83f