### PR TITLE
feat(api): add ALLOWED_ORIGINS for CORS

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,6 +1,8 @@
 PORT=4000
 # required token for API access
 API_TOKEN=changeme
+# comma-separated list of allowed CORS origins
+# ALLOWED_ORIGINS=http://localhost:3000
 # BLENDER_PATH="C:\\Program Files\\Blender Foundation\\Blender 4.5\\blender.exe"
 # maximum upload size in bytes
 # MAX_UPLOAD_BYTES=52428800

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -17,6 +17,7 @@ The API can be configured with the following environment variables:
   Defaults to `2`.
 - `QUEUE_LIMIT` – how many conversion requests may wait in queue. When the
   limit is reached, new requests are rejected with `429`. Defaults to `10`.
+- `ALLOWED_ORIGINS` – comma-separated list of allowed CORS origins (URLs).
 
 ## Allowed formats
 

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -10,7 +10,7 @@ import 'dotenv/config';
 import PQueue from 'p-queue';
 
 const app = express();
-app.use(cors());
+app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(',') }));
 const upload = multer({
   dest: 'uploads/',
   limits: {


### PR DESCRIPTION
## Summary
- allow specifying allowed CORS origins through `ALLOWED_ORIGINS`
- document `ALLOWED_ORIGINS` and add to `.env.example`

## Testing
- `node --check apps/api/server.js`
- `cd apps/api && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb4a16aadc83228f139d0c8a578eed