### PR TITLE
Encode metadata keys before upload

### DIFF
--- a/apps/android/app/src/main/java/com/mebloplan/scanner/Uploader.kt
+++ b/apps/android/app/src/main/java/com/mebloplan/scanner/Uploader.kt
@@ -15,7 +15,8 @@ object Uploader {
     private val client = OkHttpClient()
 
     suspend fun upload(url: String, token: String, file: File, meta: Map<String, String>): String {
-        val metaString = meta.entries.joinToString("&") { "${it.key}=${URLEncoder.encode(it.value, "UTF-8")}" }
+        val metaString = meta.entries.joinToString("&") {
+            "${URLEncoder.encode(it.key, "UTF-8")}=${URLEncoder.encode(it.value, "UTF-8")}" }
         val body = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
             .addFormDataPart("meta", metaString)

--- a/apps/android/app/src/test/java/com/mebloplan/scanner/UploaderTest.kt
+++ b/apps/android/app/src/test/java/com/mebloplan/scanner/UploaderTest.kt
@@ -26,4 +26,22 @@ class UploaderTest {
         assertTrue(recorded.body.readUtf8().contains("author=Jan+Kowalski"))
         server.shutdown()
     }
+
+    @Test
+    fun encodesMetaKeys() = runBlocking {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("ok"))
+        server.start()
+        val file = File.createTempFile("test", ".txt").apply { writeText("data") }
+        val result = Uploader.upload(
+            url = server.url("/upload").toString(),
+            token = "token",
+            file = file,
+            meta = mapOf("author name" to "Jan")
+        )
+        val recorded = server.takeRequest()
+        assertEquals("ok", result)
+        assertTrue(recorded.body.readUtf8().contains("author+name=Jan"))
+        server.shutdown()
+    }
 }


### PR DESCRIPTION
## Summary
- URL-encode metadata field names in `Uploader` to ensure safe multipart submissions
- Add test to validate key encoding alongside existing value checks

## Testing
- `gradle test` *(fails: Script compilation errors in app/build.gradle.kts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4bef1e008322a25045a0354c3cc9