### PR TITLE
feat(api): enforce metadata size limit

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -6,3 +6,5 @@ API_TOKEN=changeme
 # BLENDER_PATH="C:\\Program Files\\Blender Foundation\\Blender 4.5\\blender.exe"
 # maximum upload size in bytes
 # MAX_UPLOAD_BYTES=52428800
+# maximum metadata size in bytes
+# MAX_META_BYTES=16384

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -13,6 +13,8 @@ The API can be configured with the following environment variables:
   by a periodic cleanup job. Defaults to `86400000` (24 hours).
 - `MAX_UPLOAD_BYTES` – maximum allowed upload size in bytes. Defaults to
   `52428800` (50 MB).
+- `MAX_META_BYTES` – maximum allowed metadata size in bytes. Defaults to
+  `16384` (16 kB).
 - `CONCURRENCY` – maximum number of conversions processed in parallel.
   Defaults to `2`.
 - `QUEUE_LIMIT` – how many conversion requests may wait in queue. When the
@@ -39,7 +41,8 @@ Uploaded source files are deleted after conversion.
 
 Send additional metadata in a `meta` field when uploading scans. The value
 can be JSON or a URL-encoded string. The server stores the parsed data next
-to the generated model as `info.json`.
+to the generated model as `info.json`. Metadata larger than `MAX_META_BYTES`
+is rejected.
 
 ```bash
 curl -H "Authorization: Bearer $API_TOKEN" \


### PR DESCRIPTION
## Summary
- limit metadata size using `MAX_META_BYTES`
- document `MAX_META_BYTES` in `.env.example` and README

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bb532fa920832283db73cf3fc6f4ab