### PR TITLE
feat(api): add health endpoint

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -3,6 +3,11 @@
 API requires an `API_TOKEN` environment variable. Clients must send this
 token in the `Authorization: Bearer` header with each request.
 
+## Health check
+
+`GET /health` returns `{"status":"ok"}` and does not require an
+`Authorization` header. Use it to verify that the service is running.
+
 ## Configuration
 
 The API can be configured with the following environment variables:

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -3,6 +3,12 @@ info:
   title: MebloPlan Scanner API
   version: 0.1.0
 paths:
+  /health:
+    get:
+      summary: Service health check.
+      responses:
+        '200':
+          description: Service is up.
   /api/scans:
     post:
       summary: Upload scan data and convert to GLB.

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -51,6 +51,8 @@ async function cleanOldFiles() {
 setInterval(cleanOldFiles, 60 * 60 * 1000);
 cleanOldFiles();
 
+app.get('/health', (req, res) => res.json({ status: 'ok' }));
+
 app.use((req, res, next) => {
   const auth = req.headers.authorization || '';
   const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';


### PR DESCRIPTION
## Summary
- add `/health` endpoint for unauthenticated service checks
- document health check in README and OpenAPI spec

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb5709c8388322ada14d1aa5a80c44