### PR TITLE
Document UUID format for scan IDs

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -56,7 +56,9 @@ curl -H "Authorization: Bearer $API_TOKEN" \
   http://localhost:4000/api/scans
 ```
 
-The response contains the scan `id`. Read the saved metadata with:
+The response contains the scan `id` (UUID) and `url`. Use the returned `id`
+in `GET /api/scans/{id}/room.glb` to download the converted model. Read the
+saved metadata with:
 
 ```js
 import fs from 'fs/promises';

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -31,6 +31,22 @@ paths:
       responses:
         '200':
           description: Conversion completed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - url
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    description: Unique scan ID.
+                  url:
+                    type: string
+                    format: uri
+                    description: URL to download the GLB file.
         '400':
           description: Bad request.
         '401':
@@ -45,9 +61,11 @@ paths:
       parameters:
         - name: id
           in: path
+          description: Unique scan ID.
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         '200':
           description: GLB file.


### PR DESCRIPTION
## Summary
- specify UUID format for scan IDs in API spec
- describe UUID usage in API documentation

## Testing
- `cd apps/api && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb57b2e528832282c7ebc58c6d6b88