### PR TITLE
Use fixed locale for PLY point formatting

### DIFF
--- a/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
@@ -14,6 +14,7 @@ import com.google.ar.core.PointCloud
 import com.google.ar.core.Session
 import com.google.ar.core.exceptions.*
 import java.io.File
+import java.util.Locale
 import kotlinx.coroutines.*
 
 class MainActivity : AppCompatActivity() {
@@ -135,7 +136,8 @@ class MainActivity : AppCompatActivity() {
             pw.println("end_header")
             var i = 0
             while (i < pts.size) {
-                pw.println("${pts[i]} ${pts[i+1]} ${pts[i+2]}")
+                // Locale.US ensures '.' decimal separator regardless of device settings
+                pw.println(String.format(Locale.US, "%f %f %f", pts[i], pts[i+1], pts[i+2]))
                 i += 3
             }
         }


### PR DESCRIPTION
## Summary
- import `Locale` and use `String.format` with `Locale.US` when writing point cloud PLY files
- add a comment explaining why a constant locale is needed

## Testing
- `gradle test` *(fails: defaultConfig contains custom BuildConfig fields, but the feature is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5c745b9c832293505d1fd31dafea