### PR TITLE
Document allowed scan upload file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # 3dskaner monorepo
+
+## Dozwolone rozszerzenia
+
+| Rozszerzenie | Content-Type |
+|--------------|--------------|
+| `.obj` | `model/obj` |
+| `.ply` | `model/x-ply` |
+| `.usd` | `application/usd` |
+| `.usda` | `application/usd` |
+| `.usdz` | `model/vnd.usdz+zip` |

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -24,7 +24,7 @@ paths:
                 file:
                   type: string
                   format: binary
-                  description: ZIP file containing scan data.
+                  description: OBJ, PLY, USD/USDA/USDZ
                 meta:
                   type: string
                   description: Additional metadata encoded as JSON or URL-encoded string.


### PR DESCRIPTION
## Summary
- clarify POST /api/scans `file` description to list supported OBJ, PLY, USD/USDA/USDZ formats
- add table of allowed extensions and Content-Type values in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb5f76e6208322a32017f24813de2e