### PR TITLE
feat(api): add helmet for security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@
 | `.usd` | `application/usd` |
 | `.usda` | `application/usd` |
 | `.usdz` | `model/vnd.usdz+zip` |
+
+## Bezpieczeństwo
+
+API korzysta z biblioteki [Helmet](https://helmetjs.github.io/),
+która ustawia standardowe nagłówki bezpieczeństwa chroniące aplikację.

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "file-type": "^21.0.0",
+        "helmet": "^8.1.0",
         "multer": "^1.4.5-lts.1",
         "p-queue": "^7.4.1",
         "uuid": "^9.0.1"
@@ -554,6 +555,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "file-type": "^21.0.0",
+    "helmet": "^8.1.0",
     "multer": "^1.4.5-lts.1",
     "p-queue": "^7.4.1",
     "uuid": "^9.0.1"

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -7,6 +7,7 @@ import path from 'path';
 import fs from 'fs';
 import { pipeline } from 'stream/promises';
 import cors from 'cors';
+import helmet from 'helmet';
 import 'dotenv/config';
 import PQueue from 'p-queue';
 import FileType from 'file-type';
@@ -21,6 +22,7 @@ function parsePositiveInt(value, fallback) {
 }
 
 const app = express();
+app.use(helmet());
 app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(',') }));
 const upload = multer({
   dest: 'uploads/',


### PR DESCRIPTION
## Summary
- install helmet in API
- secure Express server with Helmet
- document usage of security headers

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb60525bf083229cc42bb91383d4a8