### PR TITLE
Configure mobile upload timeouts

### DIFF
--- a/apps/android/app/src/main/java/com/mebloplan/scanner/Uploader.kt
+++ b/apps/android/app/src/main/java/com/mebloplan/scanner/Uploader.kt
@@ -3,6 +3,7 @@ package com.mebloplan.scanner
 import java.io.File
 import java.io.IOException
 import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -12,7 +13,11 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.asRequestBody
 
 object Uploader {
-    private val client = OkHttpClient()
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build()
 
     suspend fun upload(
         url: String = BuildConfig.API_URL,

--- a/apps/ios/ContentView.swift
+++ b/apps/ios/ContentView.swift
@@ -66,6 +66,11 @@ struct ContentView: View {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = 30
+            config.timeoutIntervalForResource = 30
+            let session = URLSession(configuration: config)
+
             let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
             FileManager.default.createFile(atPath: tempURL.path, contents: nil)
             let handle = try FileHandle(forWritingTo: tempURL)
@@ -98,7 +103,7 @@ struct ContentView: View {
             try handle.write(contentsOf: "\r\n".data(using: .utf8)!)
             try handle.write(contentsOf: "--\(boundary)--\r\n".data(using: .utf8)!)
 
-            let (respData, resp) = try await URLSession.shared.upload(for: request, fromFile: tempURL)
+            let (respData, resp) = try await session.upload(for: request, fromFile: tempURL)
             if let http = resp as? HTTPURLResponse, http.statusCode == 200 {
                 uploadResult = String(data: respData, encoding: .utf8) ?? "OK"
             } else {

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -36,3 +36,7 @@ W pliku `apps/ios/Info.plist` ustaw klucze `API_URL` i `API_TOKEN`.
 ### Web
 
 Komponent `web-snippets/ImportRoom.tsx` oczekuje adresu API w propsie `apiUrl` lub w zmiennej środowiskowej `REACT_APP_API_URL`.
+
+## Limity czasowe połączeń
+
+Aplikacje mobilne używają domyślnego limitu czasu wynoszącego 30 s na nawiązanie, odczyt i zapis danych podczas komunikacji z API.


### PR DESCRIPTION
## Summary
- Add 30 s connect/read/write timeouts to Android uploader.
- Create URLSession with 30 s request/resource timeouts in iOS upload.
- Document default 30 s timeouts for mobile API communication.

## Testing
- `gradle test` (fails: defaultConfig contains custom BuildConfig fields, feature is disabled)
- `swift build` (fails: Could not find Package.swift)

------
https://chatgpt.com/codex/tasks/task_e_68bb63acb4888322985572299eb56221