### PR TITLE
Return absolute scan URL

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -56,9 +56,10 @@ curl -H "Authorization: Bearer $API_TOKEN" \
   http://localhost:4000/api/scans
 ```
 
-The response contains the scan `id` (UUID) and `url`. Use the returned `id`
-in `GET /api/scans/{id}/room.glb` to download the converted model. Read the
-saved metadata with:
+The response contains the scan `id` (UUID) and `url`, for example
+`http://localhost:4000/api/scans/{id}/room.glb`. Use this `url` or the
+`id` with `GET http://localhost:4000/api/scans/{id}/room.glb` to download
+the converted model. Read the saved metadata with:
 
 ```js
 import fs from 'fs/promises';
@@ -69,16 +70,17 @@ console.log(info.author);
 
 ## Responses
 
-Both `POST /api/scans` and `GET /api/scans/{id}/room.glb` may return:
+Both `POST http://localhost:4000/api/scans` and
+`GET http://localhost:4000/api/scans/{id}/room.glb` may return:
 
 - `401` – Unauthorized
 - `400` – Bad request
 - `500` – Server error
 
-`POST /api/scans` may also return:
+`POST http://localhost:4000/api/scans` may also return:
 
 - `429` – Too many requests (conversion queue full)
 
-`GET /api/scans/{id}/room.glb` may also return:
+`GET http://localhost:4000/api/scans/{id}/room.glb` may also return:
 
 - `404` – Not found

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -46,7 +46,8 @@ paths:
                   url:
                     type: string
                     format: uri
-                    description: URL to download the GLB file.
+                    description: Full URL to download the GLB file.
+                    example: http://localhost:4000/api/scans/123e4567-e89b-12d3-a456-426614174000/room.glb
         '400':
           description: Bad request.
         '401':

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -168,7 +168,8 @@ app.post('/api/scans', upload.single('file'), async (req, res) => {
             if (code === 0) {
               try {
                 await fs.promises.access(glbPath);
-                res.json({ id, url: `/api/scans/${id}/room.glb` });
+                const base = `${req.protocol}://${req.get('host')}`;
+                res.json({ id, url: `${base}/api/scans/${id}/room.glb` });
                 resolve();
               } catch {
                 reject(new Error('conversion failed'));


### PR DESCRIPTION
## Summary
- Include protocol and host when returning scan URL
- Document absolute URLs in README
- Provide example absolute link in OpenAPI spec

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb65b0240c8322b1b1793f268f0f66