### PR TITLE
feat(api): add request rate limiting

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -28,6 +28,8 @@ The API can be configured with the following environment variables:
   limit is reached, new requests are rejected with `429`. Defaults to `10`.
 - `ALLOWED_ORIGINS` – comma-separated list of allowed CORS origins (URLs).
 
+Requests are limited to 30 per minute.
+
 ## Allowed formats
 
 Uploads are accepted only in the following file formats:

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -11,6 +11,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^8.1.0",
         "file-type": "^21.0.0",
         "helmet": "^8.1.0",
         "multer": "^1.4.5-lts.1",
@@ -415,6 +416,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
+      "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -619,6 +638,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^8.1.0",
     "file-type": "^21.0.0",
     "helmet": "^8.1.0",
     "multer": "^1.4.5-lts.1",

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -11,6 +11,7 @@ import helmet from 'helmet';
 import 'dotenv/config';
 import PQueue from 'p-queue';
 import FileType from 'file-type';
+import rateLimit from 'express-rate-limit';
 
 function parsePositiveInt(value, fallback) {
   const parsed = parseInt(value, 10);
@@ -22,6 +23,7 @@ function parsePositiveInt(value, fallback) {
 }
 
 const app = express();
+app.use(rateLimit({ windowMs: 60 * 1000, max: 30 }));
 app.use(helmet());
 app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(',') }));
 const upload = multer({


### PR DESCRIPTION
## Summary
- add express-rate-limit dependency
- throttle API requests to 30 per minute
- document default rate limit

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68bb67a07f188322a125875e87f2696b