### PR TITLE
feat(api): make upload dir configurable

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,6 +4,8 @@ API_TOKEN=changeme
 # comma-separated list of allowed CORS origins
 # ALLOWED_ORIGINS=http://localhost:3000
 # BLENDER_PATH="C:\\Program Files\\Blender Foundation\\Blender 4.5\\blender.exe"
+# directory for temporary uploads
+# UPLOAD_DIR=uploads
 # maximum upload size in bytes
 # MAX_UPLOAD_BYTES=52428800
 # maximum metadata size in bytes

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -16,6 +16,7 @@ The API can be configured with the following environment variables:
   send it in the `Authorization: Bearer` header with each request.
 - `STORAGE_DIR` – directory where converted scans are stored. Defaults to
   `storage`.
+- `UPLOAD_DIR` – directory for temporary uploads. Defaults to `uploads`.
 - `STORAGE_MAX_AGE_MS` – files older than this many milliseconds are removed
   by a periodic cleanup job. Defaults to `86400000` (24 hours).
 - `MAX_UPLOAD_BYTES` – maximum allowed upload size in bytes. Defaults to

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -26,14 +26,15 @@ const app = express();
 app.use(rateLimit({ windowMs: 60 * 1000, max: 30 }));
 app.use(helmet());
 app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(',') }));
+const uploadDir = path.resolve(process.env.UPLOAD_DIR || 'uploads');
+const storageDir = path.resolve(process.env.STORAGE_DIR || 'storage');
 const upload = multer({
-  dest: 'uploads/',
+  dest: uploadDir,
   limits: {
     fileSize: parsePositiveInt(process.env.MAX_UPLOAD_BYTES, 52428800),
   },
 });
 
-const storageDir = process.env.STORAGE_DIR || 'storage';
 const maxFileAgeMs = parsePositiveInt(
   process.env.STORAGE_MAX_AGE_MS,
   24 * 60 * 60 * 1000
@@ -63,11 +64,10 @@ async function cleanOldFiles() {
 
 async function cleanupUploads() {
   try {
-    const dir = 'uploads';
-    const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    const entries = await fs.promises.readdir(uploadDir, { withFileTypes: true });
     let count = 0;
     for (const entry of entries) {
-      await fs.promises.rm(path.join(dir, entry.name), { recursive: true, force: true });
+      await fs.promises.rm(path.join(uploadDir, entry.name), { recursive: true, force: true });
       count++;
     }
     console.log(`cleanupUploads: removed ${count} file(s)`);


### PR DESCRIPTION
## Summary
- allow configuring upload directory via `UPLOAD_DIR`
- document `UPLOAD_DIR` in README and env example

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb693625f88322be653dce143e823c