### PR TITLE
Guard RoomPlan scanner on unsupported devices

### DIFF
--- a/apps/ios/ContentView.swift
+++ b/apps/ios/ContentView.swift
@@ -1,6 +1,7 @@
 
 import SwiftUI
 import Foundation
+import RoomPlan
 
 struct ContentView: View {
     @State private var lastExportURL: URL? = nil
@@ -12,37 +13,43 @@ struct ContentView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 16) {
-                RoomPlanScannerView { url in
-                    lastExportURL = url
-                    exportFinished = true
-                }
-                .id(scannerId)
-                .frame(maxWidth: .infinity, maxHeight: 380)
-                .background(Color.black.opacity(0.05))
-                .clipShape(RoundedRectangle(cornerRadius: 24))
+                if RoomCaptureSession.isSupported {
+                    RoomPlanScannerView { url in
+                        lastExportURL = url
+                        exportFinished = true
+                    }
+                    .id(scannerId)
+                    .frame(maxWidth: .infinity, maxHeight: 380)
+                    .background(Color.black.opacity(0.05))
+                    .clipShape(RoundedRectangle(cornerRadius: 24))
 
-                if let url = lastExportURL {
-                    Text("Zapisano: \(url.lastPathComponent)").font(.footnote).foregroundColor(.secondary)
-                    if exportFinished {
-                        Text("Eksport zakończony").font(.footnote).foregroundColor(.green)
-                    }
-                    Button { Task { await uploadFile(url: url) } } label: {
-                        HStack { if isUploading { ProgressView() }; Text("Wyślij do MebloPlan") }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isUploading)
-                    if exportFinished {
-                        Button("Skanuj ponownie") {
-                            lastExportURL = nil
-                            exportFinished = false
-                            scannerId = UUID()
+                    if let url = lastExportURL {
+                        Text("Zapisano: \(url.lastPathComponent)").font(.footnote).foregroundColor(.secondary)
+                        if exportFinished {
+                            Text("Eksport zakończony").font(.footnote).foregroundColor(.green)
                         }
+                        Button { Task { await uploadFile(url: url) } } label: {
+                            HStack { if isUploading { ProgressView() }; Text("Wyślij do MebloPlan") }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(isUploading)
+                        if exportFinished {
+                            Button("Skanuj ponownie") {
+                                lastExportURL = nil
+                                exportFinished = false
+                                scannerId = UUID()
+                            }
+                        }
+                    } else {
+                        Text("Zeskanuj pokój i zapisz plik przed wysyłką.").font(.footnote).foregroundColor(.secondary)
                     }
-                } else {
-                    Text("Zeskanuj pokój i zapisz plik przed wysyłką.").font(.footnote).foregroundColor(.secondary)
-                }
 
-                if let result = uploadResult { Text(result).font(.callout).foregroundColor(.green) }
+                    if let result = uploadResult { Text(result).font(.callout).foregroundColor(.green) }
+                } else {
+                    Text("To urządzenie nie obsługuje RoomPlan.")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
                 Spacer()
             }
             .padding()

--- a/apps/ios/RoomPlanScannerView.swift
+++ b/apps/ios/RoomPlanScannerView.swift
@@ -13,7 +13,9 @@ struct RoomPlanScannerView: UIViewRepresentable {
         config.captureMethod = .LiDAR
         view.captureSession = RoomCaptureSession()
         view.captureSession.delegate = context.coordinator
-        view.captureSession.run(configuration: config)
+        if RoomCaptureSession.isSupported {
+            view.captureSession.run(configuration: config)
+        }
         return view
     }
     func updateUIView(_ uiView: RoomCaptureView, context: Context) {}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -33,6 +33,8 @@ Wartości te zostaną udostępnione w `BuildConfig` jako `API_URL` oraz `API_TOK
 
 W pliku `apps/ios/Info.plist` ustaw klucze `API_URL` i `API_TOKEN`.
 
+Urządzenie musi obsługiwać RoomPlan (np. iPhone lub iPad z czujnikiem LiDAR).
+
 ### Web
 
 Komponent `web-snippets/ImportRoom.tsx` oczekuje adresu API w propsie `apiUrl` lub w zmiennej środowiskowej `REACT_APP_API_URL`.


### PR DESCRIPTION
## Summary
- Guard RoomCaptureSession.run with a support check
- Show a fallback message instead of the scanner on unsupported iOS devices
- Document the need for LiDAR-equipped hardware in the setup guide

## Testing
- `swiftc -typecheck apps/ios/ContentView.swift apps/ios/RoomPlanScannerView.swift 2>&1 | head -n 50` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68bb6b1389308322a757a377afb5d6e8