### PR TITLE
Handle API server graceful shutdown

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -89,3 +89,9 @@ Both `POST http://localhost:4000/api/scans` and
 `GET http://localhost:4000/api/scans/{id}/room.glb` may also return:
 
 - `404` – Not found
+
+## Graceful shutdown
+
+Terminate the process with `SIGINT` or `SIGTERM` (for example by pressing
+`Ctrl+C`). The server clears the conversion queue and runs cleanup tasks
+before exiting, ensuring temporary uploads and old files are removed.

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -241,3 +241,15 @@ app.use((err, req, res, next) => {
 
 const port = process.env.PORT || 4000;
 app.listen(port, () => console.log('API on http://localhost:' + port));
+
+const shutdown = async () => {
+  queue.clear();
+  try {
+    await Promise.all([cleanupUploads(), cleanOldFiles()]);
+  } finally {
+    process.exit(0);
+  }
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);


### PR DESCRIPTION
## Summary
- Clear queue and run cleanup tasks on SIGINT/SIGTERM before exiting
- Document graceful shutdown behavior

## Testing
- `npm test` (fails: missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bb6de437ac8322813bff74b80d1f4e