### PR TITLE
Ensure upload and storage directories exist

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -29,6 +29,8 @@ The API can be configured with the following environment variables:
   limit is reached, new requests are rejected with `429`. Defaults to `10`.
 - `ALLOWED_ORIGINS` – comma-separated list of allowed CORS origins (URLs).
 
+The upload and storage directories are created automatically if they do not exist.
+
 Requests are limited to 30 per minute.
 
 ## Allowed formats

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -22,12 +22,19 @@ function parsePositiveInt(value, fallback) {
   return parsed;
 }
 
+const uploadDir = path.resolve(process.env.UPLOAD_DIR || 'uploads');
+const storageDir = path.resolve(process.env.STORAGE_DIR || 'storage');
+
+async function initDirs() {
+  await fs.promises.mkdir(uploadDir, { recursive: true });
+  await fs.promises.mkdir(storageDir, { recursive: true });
+}
+
 const app = express();
+await initDirs();
 app.use(rateLimit({ windowMs: 60 * 1000, max: 30 }));
 app.use(helmet());
 app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(',') }));
-const uploadDir = path.resolve(process.env.UPLOAD_DIR || 'uploads');
-const storageDir = path.resolve(process.env.STORAGE_DIR || 'storage');
 const upload = multer({
   dest: uploadDir,
   limits: {


### PR DESCRIPTION
## Summary
- Create upload and storage directories at startup before configuring multer.
- Document automatic creation of upload and storage directories.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb701132948322a2f10359518008bc