### PR TITLE
Add Retry-After headers for API rate limiting

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -31,7 +31,9 @@ The API can be configured with the following environment variables:
 
 The upload and storage directories are created automatically if they do not exist.
 
-Requests are limited to 30 per minute.
+Requests are limited to 30 per minute. When a limit is exceeded the server
+responds with `429` and includes a `Retry-After: 60` header telling clients how
+many seconds to wait before retrying.
 
 ## Allowed formats
 
@@ -83,10 +85,12 @@ Both `POST http://localhost:4000/api/scans` and
 - `401` – Unauthorized
 - `400` – Bad request
 - `500` – Server error
+- `429` – Too many requests (rate limit exceeded)
 
 `POST http://localhost:4000/api/scans` may also return:
 
 - `429` – Too many requests (conversion queue full)
+  (includes a `Retry-After` header with wait time in seconds)
 
 `GET http://localhost:4000/api/scans/{id}/room.glb` may also return:
 


### PR DESCRIPTION
## Summary
- add `Retry-After` header to rate limit middleware
- include `Retry-After` header when conversion queue is full
- document the `Retry-After` header usage in the API readme

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb70e051c4832280d3583fb996d568