### PR TITLE
Document 429 response for GLB download endpoint

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -95,6 +95,7 @@ Both `POST http://localhost:4000/api/scans` and
 `GET http://localhost:4000/api/scans/{id}/room.glb` may also return:
 
 - `404` – Not found
+- `429` – Too many requests
 
 ## Graceful shutdown
 

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -85,6 +85,8 @@ paths:
           description: Unauthorized.
         '404':
           description: Not found.
+        '429':
+          description: Too many requests.
         '500':
           description: Server error.
 components:


### PR DESCRIPTION
## Summary
- document HTTP 429 response for GET /api/scans/{id}/room.glb in OpenAPI spec
- mention 429 Too many requests in API README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb7207705c8322a44e9d607e32e8d7