### PR TITLE
feat(api): verify Blender on startup

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -28,6 +28,8 @@ The API can be configured with the following environment variables:
 - `QUEUE_LIMIT` – how many conversion requests may wait in queue. When the
   limit is reached, new requests are rejected with `429`. Defaults to `10`.
 - `ALLOWED_ORIGINS` – comma-separated list of allowed CORS origins (URLs).
+- `BLENDER_PATH` – path to the Blender executable. Defaults to `blender`. The
+  server verifies Blender is available on startup.
 
 The upload and storage directories are created automatically if they do not exist.
 

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -30,8 +30,26 @@ async function initDirs() {
   await fs.promises.mkdir(storageDir, { recursive: true });
 }
 
+async function verifyBlender() {
+  const blender = process.env.BLENDER_PATH || 'blender';
+  await new Promise((resolve, reject) => {
+    const p = spawn(blender, ['--version'], { stdio: 'ignore' });
+    p.on('error', err => reject(err));
+    p.on('exit', code => {
+      if (code === 0) resolve();
+      else reject(new Error('Blender exited with code ' + code));
+    });
+  });
+}
+
 const app = express();
 await initDirs();
+try {
+  await verifyBlender();
+} catch (e) {
+  console.error('Blender check failed', e);
+  process.exit(1);
+}
 const RETRY_AFTER_SECONDS = 60;
 const rateLimitWindowMs = RETRY_AFTER_SECONDS * 1000;
 app.use(


### PR DESCRIPTION
## Summary
- ensure API verifies Blender is available by running `--version`
- exit the process with an error when Blender check fails
- document Blender requirement and `BLENDER_PATH` configuration variable

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb7298dec88322a5b1053d1ff7bdd2