### PR TITLE
Use UTF-8 when writing PLY files

### DIFF
--- a/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
@@ -156,7 +156,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun writePly(file: File, pts: List<Float>) {
-        file.printWriter().use { pw ->
+        // Always use UTF-8 to keep encoding stable across locales
+        file.printWriter(Charsets.UTF_8).use { pw ->
             pw.println("ply")
             pw.println("format ascii 1.0")
             pw.println("element vertex ${pts.size/3}")


### PR DESCRIPTION
## Summary
- use `file.printWriter(Charsets.UTF_8)` in `writePly` to enforce constant encoding
- document the importance of using UTF-8 for consistent output

## Testing
- `LC_ALL=pl_PL.UTF-8 java -jar /tmp/testWriteRead.jar`
- `gradle -p apps/android test` *(fails: defaultConfig contains custom BuildConfig fields, but the feature is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68bb74a8e6cc83228fd4ee7977cac0ab