### PR TITLE
Determine MIME type by extension in Android uploader

### DIFF
--- a/apps/android/app/src/main/java/com/mebloplan/scanner/Uploader.kt
+++ b/apps/android/app/src/main/java/com/mebloplan/scanner/Uploader.kt
@@ -19,6 +19,16 @@ object Uploader {
         .writeTimeout(30, TimeUnit.SECONDS)
         .build()
 
+    internal fun guessMimeType(file: File): String {
+        return when (file.extension.lowercase()) {
+            "obj" -> "model/obj"
+            "ply" -> "model/x-ply"
+            "usd", "usda" -> "application/usd"
+            "usdz" -> "model/vnd.usdz+zip"
+            else -> "application/octet-stream"
+        }
+    }
+
     suspend fun upload(
         url: String = BuildConfig.API_URL,
         token: String = BuildConfig.API_TOKEN,
@@ -27,13 +37,14 @@ object Uploader {
     ): String {
         val metaString = meta.entries.joinToString("&") {
             "${URLEncoder.encode(it.key, "UTF-8")}=${URLEncoder.encode(it.value, "UTF-8")}" }
+        val mime = guessMimeType(file)
         val body = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
             .addFormDataPart("meta", metaString)
             .addFormDataPart(
                 name = "file",
                 filename = file.name,
-                body = file.asRequestBody("application/octet-stream".toMediaType())
+                body = file.asRequestBody(mime.toMediaType())
             )
             .build()
 

--- a/apps/android/app/src/test/java/com/mebloplan/scanner/UploaderTest.kt
+++ b/apps/android/app/src/test/java/com/mebloplan/scanner/UploaderTest.kt
@@ -44,4 +44,21 @@ class UploaderTest {
         assertTrue(recorded.body.readUtf8().contains("author+name=Jan"))
         server.shutdown()
     }
+
+    @Test
+    fun mapsExtensionsToMimeTypes() {
+        val cases = mapOf(
+            "model.ply" to "model/x-ply",
+            "model.obj" to "model/obj",
+            "model.usd" to "application/usd",
+            "model.usda" to "application/usd",
+            "model.usdz" to "model/vnd.usdz+zip",
+            "model.bin" to "application/octet-stream",
+        )
+
+        for ((name, expected) in cases) {
+            val mime = Uploader.guessMimeType(File(name))
+            assertEquals(expected, mime, "extension ${'$'}{File(name).extension}")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- derive MIME type from file extension in `Uploader`
- replace fixed `application/octet-stream` with computed type
- add unit test for extension-to-MIME mapping

## Testing
- `gradle -p apps/android test` *(fails: defaultConfig contains custom BuildConfig fields, but the feature is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68bb775215148322920cea7dbc324458