### PR TITLE
feat: add cache-control header for scan downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@
 
 API korzysta z biblioteki [Helmet](https://helmetjs.github.io/),
 która ustawia standardowe nagłówki bezpieczeństwa chroniące aplikację.
+
+## Cache
+
+Pobrane modele GLB można cache'ować przez 24 godziny dzięki nagłówkowi
+`Cache-Control: public, max-age=86400, immutable`.

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -74,6 +74,12 @@ paths:
       responses:
         '200':
           description: GLB file.
+          headers:
+            Cache-Control:
+              description: Cache policy for the model.
+              schema:
+                type: string
+              example: public, max-age=86400, immutable
           content:
             model/gltf-binary:
               schema:

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -245,6 +245,7 @@ app.get('/api/scans/:id/room.glb', async (req, res) => {
 
     await fs.promises.access(filePath);
     res.setHeader('Content-Type', 'model/gltf-binary');
+    res.setHeader('Cache-Control', 'public, max-age=86400, immutable');
 
     const stream = fs.createReadStream(filePath);
     stream.on('error', err => {


### PR DESCRIPTION
## Summary
- add `Cache-Control` header to GLB download endpoint
- document cache headers in OpenAPI spec
- note 24h model caching in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb78d712948322bbabd0206d001ad2