### PR TITLE
fix: resolve Blender script path relative to module

### DIFF
--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -196,7 +196,10 @@ app.post('/api/scans', upload.single('file'), async (req, res) => {
         }
 
         const blender = process.env.BLENDER_PATH || 'blender';
-        const script = path.resolve('./convert_blender.py');
+        const script = path.join(
+          path.dirname(new URL(import.meta.url).pathname),
+          'convert_blender.py'
+        );
         const args = ['-b', '-P', script, '--', path.resolve(inputPath), path.resolve(glbPath)];
         console.log('[BLENDER]', blender, args.join(' '));
 


### PR DESCRIPTION
## Summary
- resolve `convert_blender.py` path based on module URL instead of CWD to keep working after transpiling and in production

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --input-type=module -e "import path from 'path';import fs from 'fs';const meta=new URL('file://' + process.cwd() + '/dist/server.js');const script=path.join(path.dirname(meta.pathname),'convert_blender.py');console.log(script);console.log('exists',fs.existsSync(script));"`


------
https://chatgpt.com/codex/tasks/task_e_68bb7a707b18832283dcb3345d4e57e7