### PR TITLE
feat(api): add request logging with Morgan

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -30,6 +30,7 @@ The API can be configured with the following environment variables:
 - `ALLOWED_ORIGINS` – comma-separated list of allowed CORS origins (URLs).
 - `BLENDER_PATH` – path to the Blender executable. Defaults to `blender`. The
   server verifies Blender is available on startup.
+- `LOG_FORMAT` – format for HTTP request logs. Defaults to `combined`.
 
 The upload and storage directories are created automatically if they do not exist.
 

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -14,6 +14,7 @@
         "express-rate-limit": "^8.1.0",
         "file-type": "^21.0.0",
         "helmet": "^8.1.0",
+        "morgan": "^1.10.1",
         "multer": "^1.4.5-lts.1",
         "p-queue": "^7.4.1",
         "uuid": "^9.0.1"
@@ -99,6 +100,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -753,6 +772,34 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/morgan": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -816,6 +863,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "express-rate-limit": "^8.1.0",
     "file-type": "^21.0.0",
     "helmet": "^8.1.0",
+    "morgan": "^1.10.1",
     "multer": "^1.4.5-lts.1",
     "p-queue": "^7.4.1",
     "uuid": "^9.0.1"

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -12,6 +12,7 @@ import 'dotenv/config';
 import PQueue from 'p-queue';
 import FileType from 'file-type';
 import rateLimit from 'express-rate-limit';
+import morgan from 'morgan';
 
 function parsePositiveInt(value, fallback) {
   const parsed = parseInt(value, 10);
@@ -43,6 +44,7 @@ async function verifyBlender() {
 }
 
 const app = express();
+app.use(morgan(process.env.LOG_FORMAT || 'combined'));
 await initDirs();
 try {
   await verifyBlender();


### PR DESCRIPTION
## Summary
- install morgan to log HTTP requests in apps/api
- log requests using morgan with configurable format (default 'combined')
- document LOG_FORMAT option in API README

## Testing
- `cd apps/api && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb7b5fdb14832291eda25d9d6be5c2