### PR TITLE
feat(api): add scan metadata endpoint

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -71,7 +71,9 @@ curl -H "Authorization: Bearer $API_TOKEN" \
 The response contains the scan `id` (UUID) and `url`, for example
 `http://localhost:4000/api/scans/{id}/room.glb`. Use this `url` or the
 `id` with `GET http://localhost:4000/api/scans/{id}/room.glb` to download
-the converted model. Read the saved metadata with:
+the converted model. The metadata saved during upload can be retrieved with
+`GET http://localhost:4000/api/scans/{id}/info` or read directly from the
+filesystem:
 
 ```js
 import fs from 'fs/promises';
@@ -82,8 +84,9 @@ console.log(info.author);
 
 ## Responses
 
-Both `POST http://localhost:4000/api/scans` and
-`GET http://localhost:4000/api/scans/{id}/room.glb` may return:
+Both `POST http://localhost:4000/api/scans`,
+`GET http://localhost:4000/api/scans/{id}/room.glb` and
+`GET http://localhost:4000/api/scans/{id}/info` may return:
 
 - `401` – Unauthorized
 - `400` – Bad request
@@ -96,6 +99,11 @@ Both `POST http://localhost:4000/api/scans` and
   (includes a `Retry-After` header with wait time in seconds)
 
 `GET http://localhost:4000/api/scans/{id}/room.glb` may also return:
+
+- `404` – Not found
+- `429` – Too many requests
+
+`GET http://localhost:4000/api/scans/{id}/info` may also return:
 
 - `404` – Not found
 - `429` – Too many requests

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -58,6 +58,42 @@ paths:
           description: Too many requests. Conversion queue is full.
         '500':
           description: Server error.
+  /api/scans/{id}/info:
+    get:
+      summary: Retrieve scan metadata by scan id.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Unique scan ID.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Metadata saved during upload.
+          headers:
+            Cache-Control:
+              description: Cache policy for the metadata.
+              schema:
+                type: string
+              example: public, max-age=86400, immutable
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Not found.
+        '429':
+          description: Too many requests.
+        '500':
+          description: Server error.
   /api/scans/{id}/room.glb:
     get:
       summary: Download converted GLB model by scan id.

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -235,6 +235,32 @@ app.post('/api/scans', upload.single('file'), async (req, res) => {
   }
 });
 
+app.get('/api/scans/:id/info', async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!/^[0-9a-f-]{36}$/.test(id)) {
+      return res.status(400).json({ error: 'invalid id' });
+    }
+
+    const baseDir = path.resolve(storageDir);
+    const filePath = path.resolve(baseDir, id, 'info.json');
+    if (!filePath.startsWith(baseDir + path.sep)) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const data = await fs.promises.readFile(filePath, 'utf8');
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Cache-Control', 'public, max-age=86400, immutable');
+    res.send(data);
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      res.status(404).json({ error: 'not found' });
+    } else {
+      res.status(500).json({ error: 'server error' });
+    }
+  }
+});
+
 app.get('/api/scans/:id/room.glb', async (req, res) => {
   try {
     const { id } = req.params;


### PR DESCRIPTION
## Summary
- add `/api/scans/:id/info` endpoint returning saved metadata
- document metadata endpoint in OpenAPI spec and README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bbdb346a5083229704ea1118dcbb66