### PR TITLE
feat(api): add downloadable filename support

### DIFF
--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -152,6 +152,11 @@ paths:
               description: Entity tag for the model. Constant for a given file.
               schema:
                 type: string
+            Content-Disposition:
+              description: Suggested filename for download. Uses `filename` from info.json if present.
+              schema:
+                type: string
+              example: attachment; filename="room.glb"
           content:
             model/gltf-binary:
               schema:

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -194,8 +194,11 @@ app.post('/api/scans', upload.single('file'), async (req, res) => {
     await fs.promises.rename(file.path, inputPath);
 
     const infoPath = path.join(outDir, 'info.json');
-    const info = { status: 'pending' };
-    if (meta) info.meta = meta;
+    const info = { status: 'pending', filename: 'room.glb' };
+    if (meta) {
+      if (meta.filename) info.filename = String(meta.filename);
+      info.meta = meta;
+    }
     await fs.promises.writeFile(infoPath, JSON.stringify(info, null, 2));
 
     queue.add(async () => {
@@ -356,6 +359,8 @@ app.get('/api/scans/:id/room.glb', async (req, res) => {
 
     res.setHeader('Content-Type', 'model/gltf-binary');
     res.setHeader('Cache-Control', 'public, max-age=86400, immutable');
+    const filename = info.filename || 'room.glb';
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
 
     const stream = fs.createReadStream(filePath);
     stream.on('error', err => {


### PR DESCRIPTION
## Summary
- stream scans with `Content-Disposition` header so downloads use attachment filenames
- support custom filenames via `filename` in `info.json`
- document `Content-Disposition` header in OpenAPI spec

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbef56add483228d4123a170372784