### PR TITLE
feat(api): add HEAD endpoints for scan resources

### DIFF
--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -120,6 +120,37 @@ paths:
           description: Too many requests.
         '500':
           description: Server error.
+    head:
+      summary: Check scan metadata existence by scan id.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Unique scan ID.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Metadata exists.
+          headers:
+            Cache-Control:
+              description: Cache policy for the metadata.
+              schema:
+                type: string
+              example: public, max-age=86400, immutable
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Not found.
+        '429':
+          description: Too many requests.
+        '500':
+          description: Server error.
   /api/scans/{id}/room.glb:
     get:
       summary: Download converted GLB model by scan id.
@@ -162,6 +193,59 @@ paths:
               schema:
                 type: string
                 format: binary
+        '304':
+          description: Not modified.
+          headers:
+            ETag:
+              description: Entity tag for the model. Constant for a given file.
+              schema:
+                type: string
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Not found.
+        '429':
+          description: Too many requests.
+        '500':
+          description: Server error.
+    head:
+      summary: Check converted GLB model by scan id.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Unique scan ID.
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: If-None-Match
+          in: header
+          description: ETag previously returned for the model.
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: GLB file headers.
+          headers:
+            Cache-Control:
+              description: Cache policy for the model.
+              schema:
+                type: string
+              example: public, max-age=86400, immutable
+            ETag:
+              description: Entity tag for the model. Constant for a given file.
+              schema:
+                type: string
+            Content-Disposition:
+              description: Suggested filename for download. Uses `filename` from info.json if present.
+              schema:
+                type: string
+              example: attachment; filename="room.glb"
         '304':
           description: Not modified.
           headers:


### PR DESCRIPTION
## Summary
- add HEAD routes for scan info and GLB download
- reuse GET validations while returning empty bodies
- document new HEAD methods in OpenAPI spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf0dbcb688322ae1e6421f7312120