### PR TITLE
Dodaj przycisk anulowania skanowania

### DIFF
--- a/apps/android/app/src/main/res/layout/activity_main.xml
+++ b/apps/android/app/src/main/res/layout/activity_main.xml
@@ -23,6 +23,14 @@
         android:visibility="gone"/>
 
     <Button
+        android:id="@+id/btnCancel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Anuluj"
+        android:visibility="gone"/>
+
+    <Button
         android:id="@+id/btnScan"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- przechowuj Job skanowania i umożliwiaj jego anulowanie
- dodaj przycisk "Anuluj" widoczny w trakcie skanowania
- przy anulowaniu przywracaj stan początkowy interfejsu

## Testing
- `gradle test` *(fails: defaultConfig contains custom BuildConfig fields, but the feature is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf3cded788322ae5cca545b6b2e48