### PR TITLE
feat(ios): enforce TLS

### DIFF
--- a/apps/ios/Info.plist
+++ b/apps/ios/Info.plist
@@ -5,8 +5,21 @@
     <key>CFBundleName</key>
     <string>MebloPlanScanner</string>
     <key>API_URL</key>
-    <string>http://localhost:4000/api/scans</string>
+    <string>https://localhost:4000/api/scans</string>
     <key>API_TOKEN</key>
     <string>REPLACE_WITH_API_TOKEN</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <false/>
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>localhost</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+            </dict>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -32,6 +32,10 @@ Wartości te zostaną udostępnione w `BuildConfig` jako `API_URL` oraz `API_TOK
 ### iOS
 
 W pliku `apps/ios/Info.plist` ustaw klucze `API_URL` i `API_TOKEN`.
+Adres w `API_URL` musi używać protokołu `https://`, ponieważ aplikacja
+wymaga połączeń szyfrowanych TLS. Jeżeli w środowisku deweloperskim
+korzystasz z serwera HTTP (np. `localhost`), dodaj odpowiedni wpis do
+`NSExceptionDomains`.
 
 Urządzenie musi obsługiwać RoomPlan (np. iPhone lub iPad z czujnikiem LiDAR).
 


### PR DESCRIPTION
## Summary
- enforce App Transport Security and explicitly disallow arbitrary loads
- default iOS API_URL uses https with exception domain for localhost
- document TLS requirement for the iOS API_URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbf4c254888322b4f1f93c5991c109