### PR TITLE
feat(api): add scans listing endpoint

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -85,6 +85,18 @@ const info = JSON.parse(await fs.readFile(`${dir}/${id}/info.json`, 'utf8'));
 console.log(info.author);
 ```
 
+## Listing scans
+
+Retrieve identifiers of stored scans:
+
+```bash
+curl -H "Authorization: Bearer $API_TOKEN" \
+  "http://localhost:4000/api/scans?page=1&limit=20"
+```
+
+The response is a JSON array of scan IDs. Use `page` (1-based) and `limit`
+parameters to paginate results. Defaults are `1` and `100` respectively.
+
 ## Deleting scans
 
 Remove stored scan data when no longer needed:
@@ -100,7 +112,8 @@ non-existing scans respond with `404`.
 
 ## Responses
 
-Both `POST http://localhost:4000/api/scans`,
+The endpoints `POST http://localhost:4000/api/scans`,
+`GET http://localhost:4000/api/scans`,
 `GET http://localhost:4000/api/scans/{id}/room.glb`,
 `GET http://localhost:4000/api/scans/{id}/info` and
 `DELETE http://localhost:4000/api/scans/{id}` may return:

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -10,6 +10,41 @@ paths:
         '200':
           description: Service is up.
   /api/scans:
+    get:
+      summary: List stored scan identifiers.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          description: 1-based page number.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: limit
+          in: query
+          description: Maximum items per page.
+          schema:
+            type: integer
+            minimum: 1
+            default: 100
+      responses:
+        '200':
+          description: Array of scan identifiers.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  format: uuid
+        '401':
+          description: Unauthorized.
+        '429':
+          description: Too many requests.
+        '500':
+          description: Server error.
     post:
       summary: Upload scan data and convert to GLB.
       security:

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -134,6 +134,26 @@ app.use((req, res, next) => {
   next();
 });
 
+app.get('/api/scans', async (req, res) => {
+  try {
+    const page = parsePositiveInt(req.query.page, 1);
+    const limit = parsePositiveInt(req.query.limit, 100);
+    const entries = await fs.promises.readdir(storageDir, {
+      withFileTypes: true,
+    });
+    const ids = entries
+      .filter(
+        entry => entry.isDirectory() && /^[0-9a-f-]{36}$/.test(entry.name)
+      )
+      .map(entry => entry.name)
+      .sort();
+    const start = (page - 1) * limit;
+    res.json(ids.slice(start, start + limit));
+  } catch (e) {
+    res.status(500).json({ error: 'server error' });
+  }
+});
+
 app.post('/api/scans', upload.single('file'), async (req, res) => {
   try {
     const file = req.file;

--- a/apps/api/test/server.test.js
+++ b/apps/api/test/server.test.js
@@ -125,6 +125,27 @@ describe('API server', () => {
     );
   });
 
+  it('lists scan ids with pagination', async () => {
+    const extraId = randomUUID();
+    await fs.mkdir(path.join(process.env.STORAGE_DIR, extraId));
+
+    const res1 = await request(app)
+      .get('/api/scans?limit=1&page=1')
+      .set('Authorization', 'Bearer testtoken');
+    const res2 = await request(app)
+      .get('/api/scans?limit=1&page=2')
+      .set('Authorization', 'Bearer testtoken');
+
+    assert.equal(res1.status, 200);
+    assert.equal(res2.status, 200);
+    assert.equal(res1.body.length, 1);
+    assert.equal(res2.body.length, 1);
+
+    const all = new Set([...res1.body, ...res2.body]);
+    assert(all.has(uploadedId));
+    assert(all.has(extraId));
+  });
+
   it('deletes scan directory', async () => {
     await request(app)
       .delete(`/api/scans/${uploadedId}`)


### PR DESCRIPTION
## Summary
- add GET `/api/scans` to list stored scan identifiers with `page` and `limit` pagination
- document listing endpoint in OpenAPI spec and README
- test listing behavior with pagination

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbf780eee88322bdf4a618a5c9aeaf