### PR TITLE
Expose Content-Length for room.glb endpoints

### DIFF
--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -223,11 +223,15 @@ paths:
               schema:
                 type: string
               example: attachment; filename="room.glb"
-          content:
-            model/gltf-binary:
+            Content-Length:
+              description: Size of the model in bytes.
               schema:
-                type: string
-                format: binary
+                type: integer
+        content:
+          model/gltf-binary:
+            schema:
+              type: string
+              format: binary
         '304':
           description: Not modified.
           headers:
@@ -235,6 +239,10 @@ paths:
               description: Entity tag for the model. Constant for a given file.
               schema:
                 type: string
+            Content-Length:
+              description: Size of the model in bytes.
+              schema:
+                type: integer
         '400':
           description: Bad request.
         '401':
@@ -281,6 +289,10 @@ paths:
               schema:
                 type: string
               example: attachment; filename="room.glb"
+            Content-Length:
+              description: Size of the model in bytes.
+              schema:
+                type: integer
         '304':
           description: Not modified.
           headers:
@@ -288,6 +300,10 @@ paths:
               description: Entity tag for the model. Constant for a given file.
               schema:
                 type: string
+            Content-Length:
+              description: Size of the model in bytes.
+              schema:
+                type: integer
         '400':
           description: Bad request.
         '401':

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -374,7 +374,7 @@ app.head('/api/scans/:id/room.glb', async (req, res) => {
       return res.status(403).end();
     }
 
-    await fs.promises.access(filePath);
+    const stat = await fs.promises.stat(filePath);
 
     const infoPath = path.resolve(baseDir, id, 'info.json');
     let info = {};
@@ -398,6 +398,7 @@ app.head('/api/scans/:id/room.glb', async (req, res) => {
     }
 
     res.setHeader('ETag', etag);
+    res.setHeader('Content-Length', stat.size);
 
     if (req.headers['if-none-match'] === etag) {
       return res.status(304).end();
@@ -432,7 +433,7 @@ app.get('/api/scans/:id/room.glb', async (req, res) => {
       return res.status(403).json({ error: 'forbidden' });
     }
 
-    await fs.promises.access(filePath);
+    const stat = await fs.promises.stat(filePath);
 
     const infoPath = path.resolve(baseDir, id, 'info.json');
     let info = {};
@@ -456,6 +457,7 @@ app.get('/api/scans/:id/room.glb', async (req, res) => {
     }
 
     res.setHeader('ETag', etag);
+    res.setHeader('Content-Length', stat.size);
 
     if (req.headers['if-none-match'] === etag) {
       return res.status(304).end();


### PR DESCRIPTION
## Summary
- include file size in HEAD and GET /api/scans/{id}/room.glb responses
- document `Content-Length` header in OpenAPI spec for 200 and 304 responses

## Testing
- `npm test` (fails: Blender exited with code 1)

------
https://chatgpt.com/codex/tasks/task_e_68bbf8b06fcc8322b89b047e2ee1c3be