### PR TITLE
Expose scan conversion progress

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -85,6 +85,21 @@ const info = JSON.parse(await fs.readFile(`${dir}/${id}/info.json`, 'utf8'));
 console.log(info.author);
 ```
 
+## Checking progress
+
+Poll the conversion status and progress while the scan is being processed:
+
+```bash
+curl -H "Authorization: Bearer $API_TOKEN" \
+  http://localhost:4000/api/scans/{id}
+```
+
+The response JSON includes:
+
+- `status` – current state (`pending`, `done` or `error`)
+- `progress` – conversion progress in percent (0–100)
+- `url` – download link for the GLB file when `status` is `done`
+
 ## Listing scans
 
 Retrieve identifiers of stored scans:

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -94,6 +94,51 @@ paths:
         '500':
           description: Server error.
   /api/scans/{id}:
+    get:
+      summary: Retrieve conversion status by id.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Unique scan ID.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Conversion status information.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - progress
+                properties:
+                  status:
+                    type: string
+                    description: Current conversion state.
+                  progress:
+                    type: integer
+                    minimum: 0
+                    maximum: 100
+                    description: Conversion progress percentage.
+                  url:
+                    type: string
+                    format: uri
+                    description: Download URL when conversion finished.
+        '400':
+          description: Bad request.
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Not found.
+        '429':
+          description: Too many requests.
+        '500':
+          description: Server error.
     delete:
       summary: Delete scan directory by id.
       security:

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -223,7 +223,7 @@ app.post('/api/scans', upload.single('file'), async (req, res) => {
     await fs.promises.rename(file.path, inputPath);
 
     const infoPath = path.join(outDir, 'info.json');
-    const info = { status: 'pending', filename: 'room.glb' };
+    const info = { status: 'pending', filename: 'room.glb', progress: 0 };
     if (meta) {
       if (meta.filename) info.filename = String(meta.filename);
       info.meta = meta;
@@ -270,6 +270,7 @@ app.post('/api/scans', upload.single('file'), async (req, res) => {
         console.error(e);
         info.status = 'error';
       } finally {
+        info.progress = 100;
         await fs.promises
           .writeFile(infoPath, JSON.stringify(info, null, 2))
           .catch(() => {});
@@ -303,7 +304,10 @@ app.get('/api/scans/:id', async (req, res) => {
 
     const data = await fs.promises.readFile(infoPath, 'utf8');
     const info = JSON.parse(data);
-    const result = { status: info.status || 'pending' };
+    const result = {
+      status: info.status || 'pending',
+      progress: typeof info.progress === 'number' ? info.progress : 0,
+    };
     const base = `${req.protocol}://${req.get('host')}`;
     if (result.status === 'done') {
       result.url = `${base}/api/scans/${id}/room.glb`;

--- a/apps/api/test/server.test.js
+++ b/apps/api/test/server.test.js
@@ -81,9 +81,11 @@ describe('API server', () => {
         .get(`/api/scans/${res.body.id}`)
         .set('Authorization', 'Bearer testtoken');
       status = pollRes.body.status || 'pending';
+      assert.equal(typeof pollRes.body.progress, 'number');
       if (status === 'pending') await new Promise(r => setTimeout(r, 10));
     }
     assert.equal(pollRes.body.status, 'done');
+    assert.equal(pollRes.body.progress, 100);
     assert.match(
       pollRes.body.url,
       new RegExp(`/api/scans/${res.body.id}/room\\.glb$`)


### PR DESCRIPTION
## Summary
- track progress percentage in `info.json` and expose it through `/api/scans/:id`
- document progress in README and OpenAPI spec
- ensure tests cover progress reporting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbfc4788e883228b59ce179a2ca24f