### PR TITLE
Add network connectivity checks before uploads

### DIFF
--- a/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
@@ -3,6 +3,8 @@ package com.mebloplan.scanner
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.content.Context
+import android.net.ConnectivityManager
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -194,6 +196,14 @@ class MainActivity : AppCompatActivity() {
 
     private fun uploadLast() {
         val f = lastPlyFile ?: run { info.text = "Brak pliku do wysłania"; return }
+
+        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val connected = cm.activeNetworkInfo?.isConnected == true
+        if (!connected) {
+            info.text = "Brak połączenia z internetem"
+            return
+        }
+
         scope.launch {
             try {
                 val resp = Uploader.upload(


### PR DESCRIPTION
## Summary
- verify connectivity on Android before uploading and display a message when offline
- use NWPathMonitor on iOS to confirm internet access before upload and show errors in red

## Testing
- `gradle test` *(fails: defaultConfig contains custom BuildConfig fields, but the feature is disabled)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfe25631c8322b839d5dbb657d326