### PR TITLE
docs(api): use 202 response with Location header

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -68,15 +68,15 @@ curl -H "Authorization: Bearer $API_TOKEN" \
   http://localhost:4000/api/scans
 ```
 
-The response contains the scan `id` (UUID) and `url`, for example
-`http://localhost:4000/api/scans/{id}/room.glb`. Use this `url` or the
-`id` with `GET http://localhost:4000/api/scans/{id}/room.glb` to download
-the converted model. Responses include an `ETag` header. The value is
-computed once after conversion and stays constant for a given file. Send this
-value in `If-None-Match` to avoid re-downloading unchanged files; the server
-returns `304` when the model has not changed. The metadata saved during upload can
-be retrieved with `GET http://localhost:4000/api/scans/{id}/info` or read
-directly from the filesystem:
+The server responds with status `202` and a JSON body containing only the scan `id`.
+The download link is returned in the `Location` header. Use this `Location` URL or
+the `id` with `GET http://localhost:4000/api/scans/{id}/room.glb` to download the
+converted model. Responses include an `ETag` header. The value is computed once
+after conversion and stays constant for a given file. Send this value in
+`If-None-Match` to avoid re-downloading unchanged files; the server returns `304`
+when the model has not changed. The metadata saved during upload can be retrieved
+with `GET http://localhost:4000/api/scans/{id}/info` or read directly from the
+filesystem:
 
 ```js
 import fs from 'fs/promises';

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -66,25 +66,26 @@ paths:
                   type: string
                   description: Additional metadata encoded as JSON or URL-encoded string.
       responses:
-        '200':
-          description: Conversion completed.
+        '202':
+          description: Conversion accepted.
+          headers:
+            Location:
+              description: URL to download the GLB file.
+              schema:
+                type: string
+                format: uri
+              example: http://localhost:4000/api/scans/123e4567-e89b-12d3-a456-426614174000/room.glb
           content:
             application/json:
               schema:
                 type: object
                 required:
                   - id
-                  - url
                 properties:
                   id:
                     type: string
                     format: uuid
                     description: Unique scan ID.
-                  url:
-                    type: string
-                    format: uri
-                    description: Full URL to download the GLB file.
-                    example: http://localhost:4000/api/scans/123e4567-e89b-12d3-a456-426614174000/room.glb
         '400':
           description: Bad request.
         '401':


### PR DESCRIPTION
## Summary
- switch POST /api/scans success response to 202 and document Location header
- clarify README to mention 202, only id returned and URL in Location header

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc07b723b48322bbb0d61d9e5e6fc5