### PR TITLE
refactor(api): use fileURLToPath for Blender script path

### DIFF
--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -5,6 +5,7 @@ import { spawn } from 'child_process';
 import { randomUUID, createHash } from 'crypto';
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
 import { pipeline } from 'stream/promises';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -273,7 +274,7 @@ app.post('/api/scans', upload.single('file'), async (req, res) => {
       try {
         const blender = process.env.BLENDER_PATH || 'blender';
         const script = path.join(
-          path.dirname(new URL(import.meta.url).pathname),
+          path.dirname(fileURLToPath(import.meta.url)),
           'convert_blender.py'
         );
         const args = ['-b', '-P', script, '--', path.resolve(inputPath), path.resolve(glbPath)];


### PR DESCRIPTION
## Summary
- import fileURLToPath from url for ESM path handling
- resolve convert_blender.py using fileURLToPath

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc092af66c8322bcd9f20fc234f601