### PR TITLE
feat(api): require token for WebSocket

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -101,6 +101,15 @@ The response JSON includes:
 - `url` – download link for the GLB file when `status` is `done`
 
 For real-time updates without polling, open a WebSocket connection to `/ws`.
+Send the same `Authorization: Bearer $API_TOKEN` header during the handshake:
+
+```js
+import WebSocket from 'ws';
+const ws = new WebSocket('ws://localhost:4000/ws', {
+  headers: { Authorization: `Bearer ${process.env.API_TOKEN}` },
+});
+```
+
 The server sends JSON messages of the form `{ "id": "<scan-id>", "progress": <number> }`
 whenever conversion progress changes.
 

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -585,7 +585,11 @@ if (!isTest) {
 
   wss = new WebSocketServer({ noServer: true });
   server.on('upgrade', (req, socket, head) => {
-    if (req.url === '/ws') {
+    const authHeader = req.headers['authorization'];
+    const token = authHeader?.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : authHeader;
+    if (req.url === '/ws' && token === process.env.API_TOKEN) {
       wss.handleUpgrade(req, socket, head, ws => {
         wss.emit('connection', ws, req);
       });


### PR DESCRIPTION
## Summary
- Validate `Authorization` token during WebSocket upgrade and disconnect unauthorized sockets
- Document how to supply bearer token when initiating WebSocket connections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc0a4d84688322a2323bf1c48eebef