### PR TITLE
Use NetworkCapabilities for connectivity check

### DIFF
--- a/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/mebloplan/scanner/MainActivity.kt
@@ -5,6 +5,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -198,8 +199,9 @@ class MainActivity : AppCompatActivity() {
         val f = lastPlyFile ?: run { info.text = "Brak pliku do wysłania"; return }
 
         val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        val connected = cm.activeNetworkInfo?.isConnected == true
-        if (!connected) {
+        val hasInternet = cm.getNetworkCapabilities(cm.activeNetwork)
+            ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+        if (!hasInternet) {
             info.text = "Brak połączenia z internetem"
             return
         }


### PR DESCRIPTION
## Summary
- replace deprecated `activeNetworkInfo` with NetworkCapabilities-based internet check
- add NetworkCapabilities import and maintain user message when no internet

## Testing
- `gradle -p apps/android tasks` *(fails: defaultConfig contains custom BuildConfig fields, but the feature is disabled)*
- `gradle -p apps/android test` *(fails: defaultConfig contains custom BuildConfig fields, but the feature is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0bed23b883229d1ee4aadbaa75a0