### PR TITLE
Allow optional metadata fields

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -61,6 +61,16 @@ can be JSON or a URL-encoded string. The server stores the parsed data next
 to the generated model as `info.json`. Metadata larger than `MAX_META_BYTES`
 is rejected.
 
+The `meta` object may contain the following keys:
+
+- `author` – **required**; name of the person creating the scan
+- `title` – optional descriptive title
+- `filename` – optional download name for the resulting model
+- `platform` – optional client platform identifier
+- `format` – optional source format description
+
+Any other keys are rejected.
+
 ```bash
 curl -H "Authorization: Bearer $API_TOKEN" \
   -F file=@scan.zip \

--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -37,8 +37,10 @@ const metaSchema = {
     title: { type: 'string' },
     author: { type: 'string' },
     filename: { type: 'string' },
+    platform: { type: 'string' },
+    format: { type: 'string' },
   },
-  required: ['title', 'author', 'filename'],
+  required: ['author'],
   additionalProperties: false,
 };
 

--- a/apps/api/test/server.test.js
+++ b/apps/api/test/server.test.js
@@ -79,9 +79,7 @@ describe('API server', () => {
       .field('meta', JSON.stringify({ author: 123 }))
       .attach('file', Buffer.from('data'), 'model.obj');
     assert.equal(res.status, 400);
-    assert(res.body.fields.includes('title'));
-    assert(res.body.fields.includes('filename'));
-    assert(res.body.fields.includes('author'));
+    assert.deepStrictEqual(res.body.fields, ['author']);
   });
 
   it('returns 400 when metadata is too large', async () => {


### PR DESCRIPTION
## Summary
- permit `platform` and `format` metadata and allow `title` and `filename` to be optional
- update API docs with list of supported metadata keys
- adjust tests for relaxed metadata requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc155fdcf483228704cead246d4e7e