### PR TITLE
ci: clarify iOS linting steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - run: brew install swift-format
-      - run: swift format lint --configuration .swift-format --strict --recursive .
+      - name: Install swift-format
+        run: brew install swift-format
+      - name: Lint Swift code
+        run: swift format lint --configuration .swift-format --strict --recursive .


### PR DESCRIPTION
## Summary
- name the Swift formatting steps for the iOS job in CI
- ensure swift-format is installed via brew before linting

## Testing
- `act -j ios` *(fails: no valid Docker connection / unsupported platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bc504ac8c083229d88229a8d876468