### PR TITLE
feat: add API Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,18 @@ Pobrane modele GLB można cache'ować przez 24 godziny dzięki nagłówkowi
 Serwer wysyła też `Last-Modified`, więc klienci mogą użyć nagłówka
 `If-Modified-Since`, aby uniknąć pobierania niezmienionych plików (odpowiedź
 `304`).
+
+## Docker
+
+### Budowa obrazu
+
+```bash
+docker build -t stawiaczscian-api apps/api
+```
+
+### Uruchamianie
+
+```bash
+docker run -p 3000:3000 stawiaczscian-api
+```
+

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20
+
+# Install Blender
+RUN apt-get update && apt-get install -y blender && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install --production
+
+COPY . .
+
+ENTRYPOINT ["node", "server.js"]


### PR DESCRIPTION
## Summary
- add Dockerfile for API based on Node image with Blender
- document Docker image build and run steps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c59075883228202c47ee406aa6a