### PR TITLE
chore(api): enforce API token at startup

### DIFF
--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -19,6 +19,11 @@ import Ajv from 'ajv';
 import { WebSocketServer, WebSocket } from 'ws';
 import readline from 'readline';
 
+if (!process.env.API_TOKEN) {
+  console.error('API_TOKEN required');
+  process.exit(1);
+}
+
 function parsePositiveInt(value, fallback) {
   const parsed = parseInt(value, 10);
   if (Number.isNaN(parsed) || parsed <= 0) {

--- a/apps/api/test/api_token_required.test.js
+++ b/apps/api/test/api_token_required.test.js
@@ -1,0 +1,28 @@
+import { spawn } from 'child_process';
+import assert from 'assert';
+import { fileURLToPath } from 'url';
+
+const serverPath = fileURLToPath(new URL('../server.js', import.meta.url));
+
+describe('API server startup', () => {
+  it('fails when API_TOKEN is missing', async () => {
+    const env = { ...process.env };
+    delete env.API_TOKEN;
+    const proc = spawn('node', [serverPath], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+    proc.stderr.on('data', data => {
+      stderr += data.toString();
+    });
+
+    const code = await new Promise(resolve => {
+      proc.on('close', resolve);
+    });
+
+    assert.notStrictEqual(code, 0);
+    assert(stderr.includes('API_TOKEN required'));
+  });
+});


### PR DESCRIPTION
## Summary
- fail to start if API_TOKEN is missing
- test for missing API token

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcae5556d48322868c7151201ac1b2