### PR TITLE
chore: remove unused URL session configuration

### DIFF
--- a/apps/ios/ContentView.swift
+++ b/apps/ios/ContentView.swift
@@ -11,7 +11,6 @@ struct ContentView: View {
   @State private var scannerId = UUID()
   @State private var uploadProgress: Double = 0
   @State private var currentTask: URLSessionUploadTask? = nil
-  @State private var urlSessionConfiguration: URLSessionConfiguration? = nil
 
   var body: some View {
     NavigationView {


### PR DESCRIPTION
## Summary
- remove leftover `urlSessionConfiguration` state

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb6285b588322a5d3bec816eb230b