### PR TITLE
Handle network monitor timeout

### DIFF
--- a/apps/ios/ContentView.swift
+++ b/apps/ios/ContentView.swift
@@ -86,11 +86,12 @@ struct ContentView: View {
 
   func uploadFile(url: URL) async {
     let monitor = NWPathMonitor()
-    let path = await withCheckedContinuation { continuation in
-      monitor.pathUpdateHandler = { path in
-        continuation.resume(returning: path)
-      }
-      monitor.start(queue: DispatchQueue.global(qos: .background))
+    monitor.start(queue: DispatchQueue.global(qos: .background))
+    var path = monitor.currentPath
+    if path.status == .requiresConnection {
+      // Give the monitor up to one second to report an updated path.
+      try? await Task.sleep(nanoseconds: 1_000_000_000)
+      path = monitor.currentPath
     }
     monitor.cancel()
     guard path.status == .satisfied else {


### PR DESCRIPTION
## Summary
- add timeout fallback for NWPathMonitor in upload flow

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb8a15e848322a5a926392d388991