### PR TITLE
feat: add multipart builder

### DIFF
--- a/apps/ios/MultipartFormData.swift
+++ b/apps/ios/MultipartFormData.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct MultipartFormData {
+  let boundary: String
+  private var body = Data()
+
+  init(boundary: String = "Boundary-\(UUID().uuidString)") {
+    self.boundary = boundary
+  }
+
+  mutating func append(name: String, data: Data, filename: String? = nil, mimeType: String) {
+    body.append("--\(boundary)\r\n")
+    var disposition = "Content-Disposition: form-data; name=\"\(name)\""
+    if let filename = filename {
+      disposition += "; filename=\"\(filename)\""
+    }
+    body.append("\(disposition)\r\n")
+    body.append("Content-Type: \(mimeType)\r\n\r\n")
+    body.append(data)
+    body.append("\r\n")
+  }
+
+  mutating func append(name: String, string: String) {
+    append(name: name, data: Data(string.utf8), mimeType: "text/plain")
+  }
+
+  func finalize() -> Data {
+    var data = body
+    data.append("--\(boundary)--\r\n")
+    return data
+  }
+
+  var contentType: String {
+    "multipart/form-data; boundary=\(boundary)"
+  }
+}
+
+extension Data {
+  fileprivate mutating func append(_ string: String) {
+    if let data = string.data(using: .utf8) {
+      append(data)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- build multipart form data in memory using a new helper
- upload files using the new builder instead of temporary files

## Testing
- `swift-format -i apps/ios/MultipartFormData.swift apps/ios/ContentView.swift`
- `swiftc -typecheck apps/ios/ContentView.swift apps/ios/MultipartFormData.swift` *(fails: no such module 'Network')*


------
https://chatgpt.com/codex/tasks/task_e_68bd6ae95ec08322ae5f12a965a23cf0