### PR TITLE
Enable AndroidX and Jetifier

### DIFF
--- a/apps/android/gradle.properties
+++ b/apps/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable AndroidX and Jetifier in the Android app via gradle.properties

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8ff5481483228747c88ee18c2f96